### PR TITLE
Remove secret key usage

### DIFF
--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -1,9 +1,8 @@
 import * as ChartMogul from 'chartmogul-node';
 
-const config = new ChartMogul.Config("token", "secret", "baseURL");
+const config = new ChartMogul.Config("token", "baseURL");
 config.retries = 10;
 config.getAccountToken(); // $ExpectType string
-config.getSecretKey(); // $ExpectType string
 config.VERSION; // $ExpectType string
 
 ChartMogul.Ping.ping(config); // $ExpectType Promise<string>

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for chartmogul-node 1.0
+// Type definitions for chartmogul-node 2.0
 // Project: https://github.com/chartmogul/chartmogul-node
 // Definitions by: ChartMogul <https://github.com/chartmogul>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,9 +10,8 @@ export class Config {
     API_BASE: string;
     retries: number;
 
-    constructor(token: string, secret: string, base?: string);
+    constructor(token: string, base?: string);
     getAccountToken(): string;
-    getSecretKey(): string;
 }
 
 export namespace Ping {


### PR DESCRIPTION
This PR brings the `types` package up to date to reflect changes we made in ChartMogul's SDK.
I ran the tests locally and they pass.
